### PR TITLE
Add clock source for ESP32-C6 types

### DIFF
--- a/OneWireESP32.cpp
+++ b/OneWireESP32.cpp
@@ -71,7 +71,7 @@ OneWire32::OneWire32(uint8_t pin){
 	
 	const rmt_rx_channel_config_t rxconf = {
 		.gpio_num = owpin,
-		.clk_src = RMT_CLK_SRC_APB,
+		.clk_src = RMT_CLK_SRC_DEFAULT,
 		.resolution_hz = 1000000,
 		.mem_block_symbols = MAX_BLOCKS
 	};
@@ -82,7 +82,7 @@ OneWire32::OneWire32(uint8_t pin){
 
 	const rmt_tx_channel_config_t txconf = {
 		.gpio_num = owpin,
-		.clk_src = RMT_CLK_SRC_APB,
+		.clk_src = RMT_CLK_SRC_DEFAULT,
 		.resolution_hz = 1000000,
 		.mem_block_symbols = MAX_BLOCKS,
 		.trans_queue_depth = 4,

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=esp32-ds18b20
-version=2.0.1
+version=2.0.2
 author=junkfix
 maintainer=junkfix
 sentence=Minimal, non-blocking, DS18B20 sensor library for ESP32 using RMT pheripheral, supports multiple sensors, lightweight, no dependencies, will need Arduino esp32 3.x based on IDF 5.X 


### PR DESCRIPTION
The current clock-source (APB clock) is not available on the ESP32 C6
With these changes I was able to readout a DS18B20 on the C6 using GPIO 4